### PR TITLE
Switch to Node v4 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ client.
 What this role does:
 
 - Installs [Supervisor](http://supervisord.org/) to run The Lounge in the background
-- Installs [NodeSource Node.js 0.12](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories)
+- Installs [NodeSource's Node.js 4.x LTS](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
 - Installs [The Lounge v1.5.0](https://github.com/thelounge/lounge/blob/master/CHANGELOG.md)
 - Creates a system user to own the `lounge` process
 - Configures The Lounge [as a private server](https://theloungegithub.io/docs/server/configuration.html#public) to enable user login

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,14 +6,13 @@
     state: present
   sudo: yes
 
-# See https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories
-- name: Ensure script to install NodeSource Node.js 0.12 repo has been executed
+- name: Ensure script to install NodeSource Node.js 4.x repo has been executed
   shell:
-    curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
+    curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
     creates=/etc/apt/sources.list.d/nodesource.list
   sudo: yes
 
-- name: Ensure Node.js 0.12 is installed
+- name: Ensure Node.js 4.x (LTS) is installed
   apt:
     pkg: nodejs
     state: present


### PR DESCRIPTION
Fixes #13.

Turns out, this is a very crappy way to do so, but also the easiest/fastest.

One major flaw is that folks already using this role (there is me, and maybe another soul 😄) will not see Node.js upgraded until they manually delete or update their existing `/etc/apt/sources.list.d/nodesource.list`. Sucks, really.

There got to be a better way, [I sort of gave it a try](https://github.com/astorije/ansible-lounge/compare/master...astorije/custom-nodejs-version), but I encourage anyone who thinks has a better solution to do so.
