### PR TITLE
Add systemd support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 env:
   - ANSIBLE_VERSION="2.2.*"
-  - ANSIBLE_VERSION="2.1.*"
-  - ANSIBLE_VERSION="2.0.*"
-  - ANSIBLE_VERSION="1.9.*"
-  - ANSIBLE_VERSION="1.8.*"
+  # - ANSIBLE_VERSION="2.1.*"
+  # - ANSIBLE_VERSION="2.0.*"
+  # - ANSIBLE_VERSION="1.9.*"
+  # - ANSIBLE_VERSION="1.8.*"
   # - ANSIBLE_VERSION="1.7.*"
   # - ANSIBLE_VERSION="1.6.*"
   # - ANSIBLE_VERSION="1.5.*"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ client.
 
 What this role does:
 
-- Installs [Supervisor](http://supervisord.org/) to run The Lounge in the background
+- Uses [Supervisor](http://supervisord.org/) or `systemd` to run The Lounge in the background (supervisord will be installed when selected)
 - Installs [NodeSource's Node.js 4.x LTS](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
 - Installs [The Lounge v2.4.0](https://github.com/thelounge/lounge/blob/master/CHANGELOG.md)
 - Creates a system user to own the `lounge` process
@@ -102,6 +102,12 @@ npm install bcryptjs
 (Note that the `bcrypt` command is prefixed with a whitespace to
 [not be saved in your `bash` history](http://askubuntu.com/a/15929/166928),
 if configured accordingly).
+
+### `lounge_init_system`
+
+Sets the software that is used to start `lounge`.
+
+This variable is **optional** can be set to `systemd` or `supervisord` (default).
 
 ### `lounge_version`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ of configuration files.
 
 ## Requirements
 
-This role should be compatible with Ansible 1.2 or higher.
+This role should be compatible with Ansible 2.2 or higher.
 
 It was written for Debian and Ubuntu distributions.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ lounge_prefetch: false
 lounge_theme: example
 lounge_users: []
 lounge_version: "2.4.0"
+lounge_init_system: "supervisord"

--- a/files/lounge_systemd.service
+++ b/files/lounge_systemd.service
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+
+[Service]
+WorkingDirectory=/etc/lounge
+ExecStart=/usr/bin/lounge start --home /etc/lounge/
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=lounge
+User=lounge
+Group=lounge
+
+[Install]
+WantedBy=multi-user.target

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,17 @@
     name: lounge
     state: restarted
   sudo: yes
+  listen: Restart lounge
+  when: lounge_init_system == "supervisord"
+
+- name: Restart systemd lounge service
+  service:
+    name: lounge
+    state: restarted
+    daemon_reload: yes
+  sudo: yes
+  listen: Restart lounge
+  when: lounge_init_system == "systemd"
 
 - name: Clean up npm temporary files
   shell: rm -rf /tmp/npm-*

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
   supervisorctl:
     name: lounge
     state: restarted
-  sudo: yes
+  become: yes
   listen: Restart lounge
   when: lounge_init_system == "supervisord"
 
@@ -13,10 +13,10 @@
     name: lounge
     state: restarted
     daemon_reload: yes
-  sudo: yes
+  become: yes
   listen: Restart lounge
   when: lounge_init_system == "systemd"
 
 - name: Clean up npm temporary files
   shell: rm -rf /tmp/npm-*
-  sudo: yes
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,20 +4,20 @@
   apt:
     pkg: supervisor
     state: present
-  sudo: yes
+  become: yes
   when: lounge_init_system == "supervisord"
 
 - name: Ensure script to install NodeSource Node.js 4.x repo has been executed
   shell:
     curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
     creates=/etc/apt/sources.list.d/nodesource.list
-  sudo: yes
+  become: yes
 
 - name: Ensure that the latest version of Node.js 4.x (LTS) is installed
   apt:
     pkg: nodejs
     state: latest
-  sudo: yes
+  become: yes
 
 - name: Ensure thelounge package is installed
   npm:
@@ -26,7 +26,7 @@
     production: yes
     version: "{{ lounge_version }}"
     state: present
-  sudo: yes
+  become: yes
   notify:
     - Restart lounge
     - Clean up npm temporary files
@@ -38,7 +38,7 @@
     comment: The Lounge IRC
     system: yes
     state: present
-  sudo: yes
+  become: yes
 
 - name: Ensure JS and JSON syntax checking packages are installed
   npm:
@@ -49,27 +49,27 @@
   with_items:
     - esprima
     - jsonlint
-  sudo: yes
+  become: yes
 
 - name: Ensure lounge configuration directory is present
   file:
     path: /etc/lounge
     state: directory
-  sudo: yes
+  become: yes
 
 - name: Ensure The Lounge is configured
   template:
     src: config.js.j2
     dest: /etc/lounge/config.js
     validate: 'esvalidate %s'
-  sudo: yes
+  become: yes
   notify: Restart lounge
 
 - name: Ensure user configuration directory is present
   file:
     path: /etc/lounge/users
     state: directory
-  sudo: yes
+  become: yes
   notify: Restart lounge
 
 - name: Ensure preview storage directory is present
@@ -79,7 +79,7 @@
     group: lounge
     mode: "0770"
     state: directory
-  sudo: yes
+  become: yes
   notify: Restart lounge
 
 - name: Ensure user configuration files are present
@@ -92,14 +92,14 @@
     force: no # Do not overwrite existing users to not erase networks
     validate: 'jsonlint -q %s'
   with_items: "{{ lounge_users }}"
-  sudo: yes
+  become: yes
   notify: Restart lounge
 
 - name: Ensure program configuration for supervisord is installed
   copy:
     src: lounge_supervisord.conf
     dest: /etc/supervisor/conf.d/lounge.conf
-  sudo: yes
+  become: yes
   notify: Restart lounge
   when: lounge_init_system == "supervisord"
 
@@ -107,7 +107,7 @@
   supervisorctl:
     name: lounge
     state: present
-  sudo: yes
+  become: yes
   notify: Restart lounge
   when: lounge_init_system == "supervisord"
 
@@ -115,7 +115,7 @@
   copy:
     dest: /etc/systemd/system/lounge.service
     src: lounge_systemd.service
-  sudo: yes
+  become: yes
   notify: Restart lounge
   when: lounge_init_system == "systemd"
 
@@ -124,5 +124,5 @@
     name: lounge
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
   when: lounge_init_system == "systemd"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     pkg: supervisor
     state: present
   sudo: yes
+  when: lounge_init_system == "supervisord"
 
 - name: Ensure script to install NodeSource Node.js 4.x repo has been executed
   shell:
@@ -27,7 +28,7 @@
     state: present
   sudo: yes
   notify:
-    - Restart supervisord program
+    - Restart lounge
     - Clean up npm temporary files
 
 - name: Ensure user lounge is present
@@ -62,14 +63,14 @@
     dest: /etc/lounge/config.js
     validate: 'esvalidate %s'
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
 
 - name: Ensure user configuration directory is present
   file:
     path: /etc/lounge/users
     state: directory
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
 
 - name: Ensure preview storage directory is present
   file:
@@ -79,7 +80,7 @@
     mode: "0770"
     state: directory
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
 
 - name: Ensure user configuration files are present
   template:
@@ -92,18 +93,36 @@
     validate: 'jsonlint -q %s'
   with_items: "{{ lounge_users }}"
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
 
 - name: Ensure program configuration for supervisord is installed
   copy:
     src: lounge_supervisord.conf
     dest: /etc/supervisor/conf.d/lounge.conf
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
+  when: lounge_init_system == "supervisord"
 
 - name: Ensure lounge supervisord program is present
   supervisorctl:
     name: lounge
     state: present
   sudo: yes
-  notify: Restart supervisord program
+  notify: Restart lounge
+  when: lounge_init_system == "supervisord"
+
+- name: Ensure systemd unit file is present
+  copy:
+    dest: /etc/systemd/system/lounge.service
+    src: lounge_systemd.service
+  sudo: yes
+  notify: Restart lounge
+  when: lounge_init_system == "systemd"
+
+- name: Ensure systemd service is started
+  service:
+    name: lounge
+    state: started
+    enabled: yes
+  sudo: yes
+  when: lounge_init_system == "systemd"


### PR DESCRIPTION
i added the option to use systemd instead of supervisord. To handle both handlers with the listen directive i had to set ansible min version to >=2.2, i took the opportunity to migrate the `sudo` statements to `become` and fix the warnings.