### PR TITLE
Fix npm list when using a pre-release

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
   become: yes
 
 - name: Retrieve the location of the global `node_modules` directory
-  shell: npm list --global --parseable thelounge
+  shell: npm list --global --parseable thelounge@{{ lounge_version }}
   register: node_modules_path
   changed_when: False
   become: yes


### PR DESCRIPTION
```
$ sudo npm install --global --production thelounge@2.6.0

/usr/bin/lounge -> /usr/lib/node_modules/thelounge/index.js
thelounge@2.6.0 /usr/lib/node_modules/thelounge

$ sudo npm list --global --parseable thelounge
/usr/lib/node_modules/thelounge

$ sudo npm install --global --production thelounge@2.7.0-pre.1

/usr/bin/lounge -> /usr/lib/node_modules/thelounge/index.js
/usr/bin/thelounge -> /usr/lib/node_modules/thelounge/index.js
thelounge@2.7.0-pre.1 /usr/lib/node_modules/thelounge

$ sudo npm list --global --parseable thelounge

npm ERR! code 1
```