### PR TITLE
bump thelounge to 3.3.0 + bump Node.je to 13.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ thelounge_prefetch: false
 thelounge_reverse_proxy: false
 thelounge_theme: default
 thelounge_users: []
-thelounge_version: "3.0.1"
+thelounge_version: "3.3.0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 - name: Check whether the NodeSource script has already been executed
-  command: grep -Fq "node_8.x" /etc/apt/sources.list.d/nodesource.list
+  command: grep -Fq "node_13.x" /etc/apt/sources.list.d/nodesource.list
   register: correct_nodesource_version
   failed_when: no
   changed_when: no
 
-- name: Ensure script to install NodeSource Node.js 8.x repo has been executed
-  shell: curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+- name: Ensure script to install NodeSource Node.js 13.x repo has been executed
+  shell: curl -sL https://deb.nodesource.com/setup_13.x | sudo bash -
   when: correct_nodesource_version.rc != 0
   become: yes
 
-- name: Ensure that the latest version of Node.js 8.x (LTS) is installed
+- name: Ensure that the latest version of Node.js 13.x (LTS) is installed
   apt:
     pkg: nodejs
     state: latest
@@ -31,12 +31,11 @@
 
 - name: Ensure Yarn and Supervisor are installed
   apt:
-    pkg: "{{ item }}"
+    pkg:
+      - yarn
+      - supervisor
     state: present
     update_cache: yes
-  with_items:
-    - yarn
-    - supervisor
   become: yes
 
 - name: Ensure thelounge package is installed


### PR DESCRIPTION
also  fix DEPRECATION WARNING on ansible-2.9

The role started to throw an error on the following, so I bumped up Node.js to the newest I could find on the used URL and it solved the issue:
```
ASK [debian-thelounge : Ensure thelounge package is installed] ******************************************************************************
Saturday 07 March 2020  13:46:45 +0100 (0:01:27.178)       0:11:17.043 ******** 
fatal: [dev-thelounge]: FAILED! => changed=false 
  cmd: /usr/bin/yarn global add '' --no-emoji
  msg: |-
    warning thelounge > sqlite3 > request@2.88.2:********@10.1.0: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"
    error Found incompatible module.
  rc: 1
  stderr: |-
    warning thelounge > sqlite3 > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
    error got@10.1.0: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"
    error Found incompatible module.
  stderr_lines: <omitted>
  stdout: |-
    yarn global v1.22.1
    [1/4] Resolving packages...
    [2/4] Fetching packages...
    info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
  stdout_lines: <omitted>
```